### PR TITLE
Plugin button is invisible if language != kotlin

### DIFF
--- a/src/main/kotlin/io.github.divinenickname.kotlin.utgen.idea.plugin/GenerateUnitTest.kt
+++ b/src/main/kotlin/io.github.divinenickname.kotlin.utgen.idea.plugin/GenerateUnitTest.kt
@@ -55,4 +55,11 @@ class GenerateUnitTest : AnAction() {
 
         return psiFile
     }
+
+    override fun update(e: AnActionEvent) {
+        val presentation = e.presentation
+        val file = e.getData(CommonDataKeys.VIRTUAL_FILE)
+
+        presentation.isEnabledAndVisible = file?.extension == "kt"
+    }
 }


### PR DESCRIPTION
Something went wrong in previous time and now method works as expected. When selected file is '.kt' - plugin button shows otherwise - not

close #9 